### PR TITLE
[confirm]SNS_authentication

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -12,10 +12,6 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     callback_from :google
   end
 
-  def github
-    callback_from :github
-  end
-
   private
 
   def callback_from(provider)

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -276,7 +276,6 @@ Devise.setup do |config|
   config.omniauth :twitter,ENV['TWITTER_CLIENT_ID'],ENV['TWITTER_CLIENT_SECRET']
   config.omniauth :facebook,ENV['FACEBOOK_CLIENT_ID'],ENV['FACEBOOK_CLIENT_SECRET']
   config.omniauth :google_oauth2,ENV['GOOGLE_CLIENT_ID'],ENV['GOOGLE_CLIENT_SECRET'], name: :google
-  config.omniauth :github,ENV['GOOGLE_CLIENT_ID'],ENV['GOOGLE_CLIENT_SECRET']
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or


### PR DESCRIPTION
・GitHubでは、emailの情報をomniauthのみで取得することはできないことが判明したため、時間との兼ね合いから導入を断念しました。

・Facebookはローカル環境でのリダイレクトURIとしてCloud9のURLが許可されないため、本番環境で動作確認を行います。